### PR TITLE
Background-Polling

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function DenonAVRAccessory(log, config) {
 			that.log("poll end, state: "+data);
 			
 			if (that.switchService ) {
-				that.switchService.getCharacteristic(Characteristic.On).setValue(that.state, null, "statuspoll");
+				that.switchService.getCharacteristic(Characteristic.On).updateValue(that.state, null, "statuspoll");
 			}
 		});
 	}

--- a/index.js
+++ b/index.js
@@ -135,7 +135,6 @@ DenonAVRAccessory.prototype.setVolume = function (pVol, callback) {
     this.denon.setVolume(volume, function (err) {
         if (err) {
             this.log('set Volume error: ' + err);
-            callback(err);
         } else {
             this.log('set Volume to: ' + volume);
             callback(null);

--- a/index.js
+++ b/index.js
@@ -72,8 +72,6 @@ DenonAVRAccessory.prototype.getPowerState = function (callback, context) {
 
 
 DenonAVRAccessory.prototype.setPowerState = function (powerState, callback, context) {
-	
-	this.log("set context "+context);
 	var that = this;
 
 	//if context is statuspoll, then we need to ensure that we do not set the actual value

--- a/lib/denon.js
+++ b/lib/denon.js
@@ -14,7 +14,7 @@ var inputs = ['CD', 'SPOTIFY', 'CBL/SAT', 'DVD', 'BD', 'GAME', 'GAME2', 'AUX1',
 var Denon = function (ip) {
     this.ip = ip;
     this.status_url = '/goform/formMainZone_MainZoneXml.xml';
-	this.timeout = 60000;
+	this.timeout = 5000;
 };
 
 

--- a/lib/denon.js
+++ b/lib/denon.js
@@ -14,7 +14,7 @@ var inputs = ['CD', 'SPOTIFY', 'CBL/SAT', 'DVD', 'BD', 'GAME', 'GAME2', 'AUX1',
 var Denon = function (ip) {
     this.ip = ip;
     this.status_url = '/goform/formMainZone_MainZoneXml.xml';
-	this.timeout = 1000;
+	this.timeout = 60000;
 };
 
 

--- a/lib/denon.js
+++ b/lib/denon.js
@@ -14,6 +14,7 @@ var inputs = ['CD', 'SPOTIFY', 'CBL/SAT', 'DVD', 'BD', 'GAME', 'GAME2', 'AUX1',
 var Denon = function (ip) {
     this.ip = ip;
     this.status_url = '/goform/formMainZone_MainZoneXml.xml';
+	this.timeout = 1000;
 };
 
 
@@ -22,7 +23,10 @@ var Denon = function (ip) {
  * @param callback
  */
 Denon.prototype.getModelInfo = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + this.status_url,
+			timeout: this.timeout
+		}, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode == 200) {
             parseString(xml + body, function (err, result) {
@@ -41,7 +45,10 @@ Denon.prototype.getModelInfo = function (callback) {
  * @param callback
  */
 Denon.prototype.getName = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + this.status_url,
+			timeout: this.timeout
+		}, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode == 200) {
             parseString(xml + body, function (err, result) {
@@ -57,7 +64,10 @@ Denon.prototype.getName = function (callback) {
  * @param callback
  */
 Denon.prototype.getBrand = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + this.status_url,
+			timeout: this.timeout
+		}, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode == 200) {
             parseString(xml + body, function (err, result) {
@@ -72,7 +82,10 @@ Denon.prototype.getBrand = function (callback) {
  * @param callback
  */
 Denon.prototype.getPowerState = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + this.status_url,
+			timeout: this.timeout
+		}, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode == 200) {
             parseString(xml + body, function (err, result) {
@@ -89,7 +102,10 @@ Denon.prototype.getPowerState = function (callback) {
  */
 Denon.prototype.setPowerState = function (powerState, callback) {
     powerState = (powerState) ? 'ON' : 'OFF';
-    request.get('http://' + this.ip + '/MainZone/index.put.asp?cmd0=PutZone_OnOff/' + powerState, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + '/MainZone/index.put.asp?cmd0=PutZone_OnOff/' + powerState,
+			timeout: this.timeout
+		}, function (error, response, body) {
         if (!error && response.statusCode == 200) {
             callback(null, powerState == 'ON');
         } else {
@@ -103,7 +119,10 @@ Denon.prototype.setPowerState = function (powerState, callback) {
  * @param callback
  */
 Denon.prototype.getMuteState = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + this.status_url,
+			timeout: this.timeout
+		}, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode == 200) {
             parseString(xml + body, function (err, result) {
@@ -120,7 +139,10 @@ Denon.prototype.getMuteState = function (callback) {
  */
 Denon.prototype.setMuteState = function(muteState, callback) {
     muteState = (muteState) ? 'ON' : 'OFF';
-    request.get('http://' + this.ip + '/MainZone/index.put.asp?cmd0=PutVolumeMute/' + muteState, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + '/MainZone/index.put.asp?cmd0=PutVolumeMute/' + muteState,
+			timeout: this.timeout
+		}, function (error, response, body) {
         if(!error && response.statusCode == 200) {
             callback(null, muteState == 'ON');
         } else {
@@ -134,7 +156,10 @@ Denon.prototype.setMuteState = function(muteState, callback) {
  * @param callback (String)
  */
 Denon.prototype.getInput = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + this.status_url,
+			timeout: this.timeout
+		}, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode == 200) {
             parseString(xml + body, function (err, result) {
@@ -153,7 +178,10 @@ Denon.prototype.getInput = function (callback) {
  */
 Denon.prototype.setInput = function (input, callback) {
     if (!!~inputs.indexOf(input)) {
-        request.get('http://' + this.ip + '/goform/formiPhoneAppDirect.xml?SI' + input, function (error, response, body) {
+        request.get({
+				uri: 'http://' + this.ip + '/goform/formiPhoneAppDirect.xml?SI' + input,
+				timeout: this.timeout
+			}, function (error, response, body) {
             if (!error && response.statusCode == 200) {
                 callback(null);
             } else {
@@ -168,7 +196,10 @@ Denon.prototype.setInput = function (input, callback) {
  * @param callback
  */
 Denon.prototype.getSurroundMode = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + this.status_url,
+			timeout: this.timeout
+		}, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode == 200) {
             parseString(xml + body, function (err, result) {
@@ -186,7 +217,10 @@ Denon.prototype.getSurroundMode = function (callback) {
  */
 Denon.prototype.setVolume = function (volume, callback) {
     var vol = (volume - 80).toFixed(1);  //volume fix
-    request.get('http://' + this.ip + '/goform/formiPhoneAppVolume.xml?1+' + vol, function (error, response, body) {
+    request.get(	{
+			uri: 'http://' + this.ip + '/goform/formiPhoneAppVolume.xml?1+' + vol,
+			timeout: this.timeout
+		}, function (error, response, body) {
         if (!error && response.statusCode == 200) {
             callback(null);
         } else {
@@ -200,7 +234,10 @@ Denon.prototype.setVolume = function (volume, callback) {
  * @param callback
  */
 Denon.prototype.getVolume = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get({
+			uri: 'http://' + this.ip + this.status_url,
+			timeout: this.timeout
+		}, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode == 200) {
             parseString(xml + body, function (err, result) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "request": "^2.69.0",
     "util": "^0.10.3",
-    "xml2js": "0.4.x"
+    "xml2js": "0.4.x",
+	"polling-to-event": "2.0.2"
   }
 }


### PR DESCRIPTION
At my setup the AVR-Receiver is behind a remote switchable outlet so it is not powered all the day. In this situations the _homebridge-denon_ plugin was blocking the complete homebridge because it was caught in the _getStatus_ request until the request-timeout kicks in.
So I added background-polling for _getStatus_ (which I copied from https://github.com/gw-wiscon/homebridge-philipstv)