### PR TITLE
Add support for specifying the HTTP API port

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Example:
               "accessory": "DenonMarantzAVR",
               "name": "Denon LivingRoom",
               "ip": "192.168.1.99",
+              "port": 8080,
               "defaultInput": "IRADIO",
               "defaultVolume": 35,
               "minVolume": 10,

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ function DenonAVRAccessory(log, config) {
 	
     this.config = config;
     this.ip = config['ip'];
+    this.port = config['port'] || 80;
+
     this.name = config['name'];
 
     this.defaultInput = config['defaultInput'] || null;
@@ -28,7 +30,7 @@ function DenonAVRAccessory(log, config) {
 	this.pollingInterval = config['pollingInterval'] || "60";
 	this.pollingInterval = parseInt(this.pollingInterval)
 
-    this.denon = new Denon(this.ip);
+    this.denon = new Denon(this.ip, this.port);
 	
 	this.setAttempt = 0;
 	this.state = false;

--- a/lib/denon.js
+++ b/lib/denon.js
@@ -6,8 +6,9 @@
 var request = require('request');
 var parseString = require('xml2js').parseString;
 
-var Denon = function (ip) {
+var Denon = function (ip, port) {
     this.ip = ip;
+    this.port = port;
     this.status_url = '/goform/formMainZone_MainZoneXml.xml';
 };
 
@@ -17,7 +18,7 @@ var Denon = function (ip) {
  * @param callback
  */
 Denon.prototype.getModelInfo = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + this.status_url, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode === 200) {
             parseString(xml + body, function (err, result) {
@@ -38,7 +39,7 @@ Denon.prototype.getModelInfo = function (callback) {
  * @param callback
  */
 Denon.prototype.getName = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + this.status_url, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode === 200) {
             parseString(xml + body, function (err, result) {
@@ -56,7 +57,7 @@ Denon.prototype.getName = function (callback) {
  * @param callback
  */
 Denon.prototype.getBrand = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + this.status_url, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode === 200) {
             parseString(xml + body, function (err, result) {
@@ -73,7 +74,7 @@ Denon.prototype.getBrand = function (callback) {
  * @param callback
  */
 Denon.prototype.getPowerState = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + this.status_url, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode === 200) {
             parseString(xml + body, function (err, result) {
@@ -92,7 +93,7 @@ Denon.prototype.getPowerState = function (callback) {
  */
 Denon.prototype.setPowerState = function (powerState, callback) {
     powerState = (powerState) ? 'ON' : 'OFF';
-    request.get('http://' + this.ip + '/MainZone/index.put.asp?cmd0=PutZone_OnOff/' + powerState, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + '/MainZone/index.put.asp?cmd0=PutZone_OnOff/' + powerState, function (error, response, body) {
         if (!error && response.statusCode === 200) {
             callback(null, powerState == 'ON');
         } else {
@@ -106,7 +107,7 @@ Denon.prototype.setPowerState = function (powerState, callback) {
  * @param callback
  */
 Denon.prototype.getMuteState = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + this.status_url, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode === 200) {
             parseString(xml + body, function (err, result) {
@@ -125,7 +126,7 @@ Denon.prototype.getMuteState = function (callback) {
  */
 Denon.prototype.setMuteState = function(muteState, callback) {
     muteState = (muteState) ? 'ON' : 'OFF';
-    request.get('http://' + this.ip + '/MainZone/index.put.asp?cmd0=PutVolumeMute/' + muteState, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + '/MainZone/index.put.asp?cmd0=PutVolumeMute/' + muteState, function (error, response, body) {
         if(!error && response.statusCode === 200) {
             callback(null, muteState == 'ON');
         } else {
@@ -139,7 +140,7 @@ Denon.prototype.setMuteState = function(muteState, callback) {
  * @param callback (String)
  */
 Denon.prototype.getInput = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + this.status_url, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode === 200) {
             parseString(xml + body, function (err, result) {
@@ -161,7 +162,7 @@ Denon.prototype.getInput = function (callback) {
  * @param callback
  */
 Denon.prototype.setInput = function (input, callback) {
-    request.get('http://' + this.ip + '/goform/formiPhoneAppDirect.xml?SI' + input, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + '/goform/formiPhoneAppDirect.xml?SI' + input, function (error, response, body) {
         if (!error && response.statusCode === 200) {
             callback(null);
         } else {
@@ -175,7 +176,7 @@ Denon.prototype.setInput = function (input, callback) {
  * @param callback
  */
 Denon.prototype.getSurroundMode = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + this.status_url, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode === 200) {
             parseString(xml + body, function (err, result) {
@@ -195,7 +196,7 @@ Denon.prototype.getSurroundMode = function (callback) {
  */
 Denon.prototype.setVolume = function (volume, callback) {
     var vol = (volume - 80).toFixed(1);  //volume fix
-    request.get('http://' + this.ip + '/goform/formiPhoneAppVolume.xml?1+' + vol, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + '/goform/formiPhoneAppVolume.xml?1+' + vol, function (error, response, body) {
         if (!error && response.statusCode === 200) {
             callback(null);
         } else {
@@ -209,7 +210,7 @@ Denon.prototype.setVolume = function (volume, callback) {
  * @param callback
  */
 Denon.prototype.getVolume = function (callback) {
-    request.get('http://' + this.ip + this.status_url, function (error, response, body) {
+    request.get('http://' + this.ip + ':' + this.port + this.status_url, function (error, response, body) {
         var xml = '';
         if (!error && response.statusCode === 200) {
             parseString(xml + body, function (err, result) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-denon",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Denon and Marantz AVR support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/sample-config.json
+++ b/sample-config.json
@@ -12,6 +12,7 @@
             "accessory": "DenonMarantzAVR",
             "name": "Denon LivingRoom",
             "ip": "192.168.1.99",
+            "port": 8080,
             "defaultInput": "IRADIO",
             "defaultVolume": 35,
             "minVolume": 0,


### PR DESCRIPTION
This may resolve #20 for others

Tested this with a North American AVR-X1500H

There's scope to refactor the URL/hostname building logic out to a unified helper but for now this was the least obtrusive way to get stuff working for me.
